### PR TITLE
Update FROM in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 ##################
 # Get base image #
 ##################
-FROM python:2-alpine
+FROM python:2.7-alpine
 
 #########################################
 # Label the instance and set maintainer #

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 ##################
 # Get base image #
 ##################
-FROM python:alpine
+FROM python:2-alpine
 
 #########################################
 # Label the instance and set maintainer #


### PR DESCRIPTION
using `FROM python:alpine` is currently throwing errors when trying to import `imap` from `itertools`

![image](https://user-images.githubusercontent.com/38021615/101199183-631f2580-3619-11eb-96b0-8567bc22194e.png)

This is because `itertools.imap()` exists in **Python 2** and was renamed in **Python 3**.  When building `FROM python:alpine` **Python 3** is used by default since **Python 2** has reached end of life.

This is causing a breakage when using this action as the Docker build fails.  By forcing Docker to use **Python 2** this breakage can be overcome.  This pull forced `FROM python:2-alpine` so that the Docker build completes.

⚠️ This is not a long term solution and should be examined further.  

When using **Python 2** the requests package breaks

![image](https://user-images.githubusercontent.com/38021615/101200745-95ca1d80-361b-11eb-9f5f-c4105c312b4b.png)
